### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php":             ">=5.3.0",
         "symfony/symfony": ">=2.0",
-        "beberlei/DoctrineExtensions":  "dev-master"
+        "beberlei/DoctrineExtensions":  "0.3.0"
     },
     "autoload": {
         "psr-0": { "Ideup\\SimplePaginatorBundle": "" }


### PR DESCRIPTION
Berbelei Doctrine extension has been updated in dev-master to version 1.0, and no longer have Paginator class, to fix this problem composer.json should require an older version of beberlei/DoctrineExtensions.
